### PR TITLE
asdf: install uv instead of python

### DIFF
--- a/{{ cookiecutter.project_slug }}/.tool-versions
+++ b/{{ cookiecutter.project_slug }}/.tool-versions
@@ -1,3 +1,3 @@
 # this file is used by asdf to automatically select the correct tool versions
 # but it also serves as a reference for non-asdf users
-python {{ cookiecutter.python_version }}.0
+uv


### PR DESCRIPTION
The Python version is managed by uv

Ticket: [APPSRE-11298](https://issues.redhat.com/browse/APPSRE-11298)